### PR TITLE
Linux: unbind the USB device from `usb-serial-simple`

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,4 @@
+* fixes interaction on recent Linux kernels (#109)
 
 2022/10/23 (1.1.5-cf19)
 * upgraded to official release v1.1.5 (spanish translation, new firmware for VDS2052)

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -335,6 +335,7 @@ EOF
 
 	write "etc/udev/rules.d/70-$_ID.rules" <<EOF
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="5345", ATTRS{idProduct}=="1234", MODE="0666"
+ACTION=="bind", DRIVER=="usb_serial_simple", ATTRS{idVendor}=="5345", ATTRS{idProduct}=="1234", ATTR{driver/unbind}="%k"
 EOF
 
 }


### PR DESCRIPTION
This fixes issue with recent Linux kernels where the USB device gets taken over the `usb-serial-simple` driver and becomes unavailable to use as raw USB device.

Addresses: https://github.com/florentbr/OWON-VDS1022/issues/109