### PR TITLE
Fix install-mac.sh corrupting files on macOS

### DIFF
--- a/install-mac.sh
+++ b/install-mac.sh
@@ -14,7 +14,7 @@ _ARCH=$(uname -m)
 
 
 write () {
-    echo -e "$(</dev/stdin)" > "$1"
+    cat > "$1"
     [ -z "$2" ] || chmod "$2" "$1"
 }
 


### PR DESCRIPTION
## Problem

On macOS, `echo` does not support the `-e` flag — it outputs it literally rather than interpreting it as a flag. The `write()` helper uses `echo -e "$(</dev/stdin)"`, which causes every file it writes to be prefixed with `-e `.

This corrupts two critical files in the app bundle:

- **`Contents/Info.plist`** — becomes invalid XML, so macOS cannot parse `CFBundleExecutable` and reports *"The application cannot be opened because its executable is missing."*
- **`Contents/MacOS/launch`** — its shebang becomes `-e #!/bin/bash`, making it non-executable

## Fix

Replace `echo -e "$(</dev/stdin)"` with `cat`, which reads stdin directly and is fully portable across macOS and Linux.

## Testing

Verified on macOS (Apple Silicon) — after this fix, `install-mac.sh` correctly writes both `Info.plist` and the `launch` script, and the app opens successfully.