### PR TITLE
Add MIT licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 florentbr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Hi florentbr,

I'm Martin Harris. I've been building [nakoscope](https://github.com/nakomis/nakoscope), a tool that uses your Python API to capture waveform data from the VDS1022 to HDF5 files for analysis — mostly by Claude via an MCP server. The Rust capture path in nakoscope also re-implements the VDS1022 USB protocol, which I derived from studying your excellent work.

The repository currently has no licence file, which technically means all rights are reserved by default. If you're happy for the project to be used and built upon (as the 54 forks and wide usage suggest), adding an MIT licence would make that explicit and allow downstream projects like mine to stand on clear legal footing.

I've attached a standard MIT licence file with your name and the original creation year (2019). Feel free to adjust the copyright line if you'd prefer different wording.

Many thanks for the reverse-engineering work — it's been invaluable.

Martin Harris